### PR TITLE
Big Update (Computer name, BeforeCommand...)

### DIFF
--- a/Alve Operating System/Alve OS/Alve_OSBoot.Cosmos
+++ b/Alve Operating System/Alve OS/Alve_OSBoot.Cosmos
@@ -58,6 +58,7 @@
     <Folder Include="Apps\User\" />
     <Folder Include="Shell\" />
     <Folder Include="System\" />
+    <Folder Include="System\Computer\" />
     <Folder Include="System\Security\" />
     <Folder Include="System\Translation\" />
     <Folder Include="System\Translation\Text\" />

--- a/Alve Operating System/Alve OS/Kernel.cs
+++ b/Alve Operating System/Alve OS/Kernel.cs
@@ -14,6 +14,7 @@ using Lang = Alve_OS.System.Translation;
 using Alve_OS.System;
 using System.IO;
 using Alve_OS.System.Users;
+using Alve_OS.System.Computer;
 
 #endregion
 
@@ -34,7 +35,6 @@ namespace Alve_OS
         public static string userLogged;
         public static string userLevelLogged;
         public static bool Logged = false;
-        public static string computerName = "Alve-PC";
 
         #endregion
 
@@ -88,7 +88,7 @@ namespace Alve_OS
             {
                 if (Logged) //If logged
                 {
-                    Console.Write(UserLevel.TypeUser() + userLogged + "~ " + current_directory + "> ");
+                    BeforeCommand();
                     var cmd = Console.ReadLine();
                     Shell.Interpreter.Interpret(cmd);
                     Console.WriteLine();
@@ -105,6 +105,53 @@ namespace Alve_OS
         }
 
         #endregion
+
+        private void BeforeCommand()
+        {
+            if (current_directory == @"0:\")
+            {
+                Console.ForegroundColor = ConsoleColor.Blue;
+                Console.Write(UserLevel.TypeUser());
+
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.Write(userLogged);
+
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.Write("@");
+
+                Console.ForegroundColor = ConsoleColor.Blue;
+                Console.Write(Info.getComputerName());
+
+                Console.ForegroundColor = ConsoleColor.Gray;
+                Console.Write("> ");
+
+                Console.ForegroundColor = ConsoleColor.White;
+            }
+            else
+            {
+                Console.ForegroundColor = ConsoleColor.Blue;
+                Console.Write(UserLevel.TypeUser());
+
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.Write(userLogged);
+
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.Write("@");
+
+                Console.ForegroundColor = ConsoleColor.Blue;
+                Console.Write(Info.getComputerName());
+
+                Console.ForegroundColor = ConsoleColor.Gray;
+                Console.Write("> ");
+
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.Write(current_directory + "~ ");
+
+                Console.ForegroundColor = ConsoleColor.White;
+            }
+            
+
+        }
 
     }
 }

--- a/Alve Operating System/Alve OS/Kernel.cs
+++ b/Alve Operating System/Alve OS/Kernel.cs
@@ -62,7 +62,7 @@ namespace Alve_OS
 
             setup.SetupVerifyCompleted();
 
-            langSelected = File.ReadAllText(@"0:\System\lang");
+            langSelected = File.ReadAllText(@"0:\System\lang.set");
 
             #region Language
             Lang.Keyboard.Init();
@@ -72,6 +72,8 @@ namespace Alve_OS
             #endregion
 
             Console.Clear();
+
+            Color.GetBackgroundTextColor();
 
             WelcomeMessage.Display();
 
@@ -125,7 +127,7 @@ namespace Alve_OS
                 Console.ForegroundColor = ConsoleColor.Gray;
                 Console.Write("> ");
 
-                Console.ForegroundColor = ConsoleColor.White;
+                Color.GetTextColor();
             }
             else
             {
@@ -147,11 +149,13 @@ namespace Alve_OS
                 Console.ForegroundColor = ConsoleColor.DarkGray;
                 Console.Write(current_directory + "~ ");
 
-                Console.ForegroundColor = ConsoleColor.White;
+                Color.GetTextColor();
             }
             
 
         }
+
+        
 
     }
 }

--- a/Alve Operating System/Alve OS/Kernel.cs
+++ b/Alve Operating System/Alve OS/Kernel.cs
@@ -35,6 +35,7 @@ namespace Alve_OS
         public static string userLogged;
         public static string userLevelLogged;
         public static bool Logged = false;
+        public static string ComputerName = "Alve-PC";
 
         #endregion
 
@@ -71,9 +72,11 @@ namespace Alve_OS
             Console.ForegroundColor = ConsoleColor.White;
             #endregion
 
+            Info.getComputerName();
+
             Console.Clear();
 
-            Color.GetBackgroundTextColor();
+            Color.GetBackgroundColor();
 
             WelcomeMessage.Display();
 
@@ -122,7 +125,7 @@ namespace Alve_OS
                 Console.Write("@");
 
                 Console.ForegroundColor = ConsoleColor.Blue;
-                Console.Write(Info.getComputerName());
+                Console.Write(Kernel.ComputerName);
 
                 Console.ForegroundColor = ConsoleColor.Gray;
                 Console.Write("> ");
@@ -141,7 +144,7 @@ namespace Alve_OS
                 Console.Write("@");
 
                 Console.ForegroundColor = ConsoleColor.Blue;
-                Console.Write(Info.getComputerName());
+                Console.Write(Kernel.ComputerName);
 
                 Console.ForegroundColor = ConsoleColor.Gray;
                 Console.Write("> ");

--- a/Alve Operating System/Alve OS/Shell/Interpreter.cs
+++ b/Alve Operating System/Alve OS/Shell/Interpreter.cs
@@ -221,10 +221,17 @@ namespace Alve_OS.Shell
                 if (argsettings.Equals("adduser"))
                 {
                     //method user
-                    string argsuser = argsettings.Remove(0, 5);
+                    string argsuser = argsettings.Remove(0, 7);
                     Users users = new Users();
 
                     users.Create(argsuser);
+
+                }
+                else if (argsettings.Equals("setcomputername"))
+                {
+                    //method computername
+                    string argspcname = argsettings.Remove(0, 15);
+                    System.Computer.Info.AskComputerName();
 
                 }
             }

--- a/Alve Operating System/Alve OS/Shell/Interpreter.cs
+++ b/Alve Operating System/Alve OS/Shell/Interpreter.cs
@@ -73,7 +73,6 @@ namespace Alve_OS.Shell
             }
             else if ((cmd.Equals("dir")) || (cmd.Equals("ls")))
             {
-                L.Text.Display("foldercontent");
                 foreach (string dir in Directory.GetDirectories(Kernel.current_directory))
                 {
                     Color.DisplayTextColor("6");
@@ -98,6 +97,68 @@ namespace Alve_OS.Shell
                     
                 }
 
+            }
+            else if ((cmd.StartsWith("dir ")) || (cmd.StartsWith("ls ")))
+            {
+                string cmddir;
+                if (cmd.StartsWith("dir "))
+                {
+                    cmddir = cmd.Remove(0, 4);
+
+                    foreach (string dir in Directory.GetDirectories(cmddir))
+                    {
+                        Color.DisplayTextColor("6");
+                        Console.Write(dir + "\t");
+                    }
+                    foreach (string file in Directory.GetFiles(cmddir))
+                    {
+                        Char formatDot = '.';
+                        string[] ext = file.Split(formatDot);
+                        string lastext = ext[ext.Length - 1];
+
+                        if ((lastext == "set") || (lastext == "nam") || (lastext == "usr"))
+                        {
+                            Color.DisplayTextColor("4");
+                            Console.Write(file + "\t");
+                        }
+                        else
+                        {
+                            Color.DisplayTextColor("1");
+                            Console.Write(file + "\t");
+                        }
+
+                    }
+                }
+                else if (cmd.StartsWith("ls "))
+                {
+                    cmddir = cmd.Remove(0, 3);
+
+                    foreach (string dir in Directory.GetDirectories(cmddir))
+                    {
+                        Color.DisplayTextColor("6");
+                        Console.Write(dir + "\t");
+                    }
+                    foreach (string file in Directory.GetFiles(cmddir))
+                    {
+                        Char formatDot = '.';
+                        string[] ext = file.Split(formatDot);
+                        string lastext = ext[ext.Length - 1];
+
+                        if ((lastext == "set") || (lastext == "nam") || (lastext == "usr"))
+                        {
+                            Color.DisplayTextColor("4");
+                            Console.Write(file + "\t");
+                        }
+                        else
+                        {
+                            Color.DisplayTextColor("1");
+                            Console.Write(file + "\t");
+                        }
+
+                    }
+                }
+
+                
             }
             else if (cmd.StartsWith("mkdir "))
             {
@@ -168,6 +229,7 @@ namespace Alve_OS.Shell
             else if (cmd.Equals("vol"))
             {
                 var vols = Kernel.FS.GetVolumes();
+                
                 L.Text.Display("NameSizeParent");
                 foreach (var vol in vols)
                 {

--- a/Alve Operating System/Alve OS/Shell/Interpreter.cs
+++ b/Alve Operating System/Alve OS/Shell/Interpreter.cs
@@ -11,6 +11,7 @@ using Sys = Cosmos.System;
 using L = Alve_OS.System.Translation;
 using Alve_OS.System;
 using Alve_OS.System.Users;
+using Alve_OS.System.Computer;
 
 namespace Alve_OS.Shell
 {
@@ -70,18 +71,31 @@ namespace Alve_OS.Shell
                     L.Text.Display("directorydoesntexist");
                 }
             }
-            else if (cmd.Equals("dir"))
+            else if ((cmd.Equals("dir")) || (cmd.Equals("ls")))
             {
-                L.Text.Display("typename");
+                L.Text.Display("foldercontent");
                 foreach (string dir in Directory.GetDirectories(Kernel.current_directory))
                 {
-                    Console.WriteLine("<DIR>\t" + dir);
+                    Color.DisplayTextColor("6");
+                    Console.Write(dir + "\t");
                 }
-                foreach (string dir in Directory.GetFiles(Kernel.current_directory))
-                {
+                foreach (string file in Directory.GetFiles(Kernel.current_directory))
+                {                    
                     Char formatDot = '.';
-                    string[] ext = dir.Split(formatDot);
-                    Console.WriteLine("<" + ext[ext.Length - 1] + ">\t" + dir);
+                    string[] ext = file.Split(formatDot);
+                    string lastext = ext[ext.Length - 1];
+
+                    if ((lastext == "set") || (lastext == "nam") || (lastext == "usr"))
+                    {
+                        Color.DisplayTextColor("4");
+                        Console.Write(file + "\t");
+                    }
+                    else
+                    {
+                        Color.DisplayTextColor("1");
+                        Console.Write(file + "\t");
+                    }
+                    
                 }
 
             }
@@ -235,44 +249,88 @@ namespace Alve_OS.Shell
 
                 }
             }
-            else if (cmd.Equals("color"))
+            else if (cmd.Equals("textcolor"))
             {
                 L.Color.Display();
             }
-            else if (cmd.StartsWith("color "))
+            else if (cmd.StartsWith("textcolor "))
             {
-                string color = cmd.Remove(0, 6);
+                string color = cmd.Remove(0, 10);
                 if (color.Equals("0"))
                 {
-                    Console.ForegroundColor = ConsoleColor.Black;
+                    Color.SetTextColor("0");
                 }
                 else if (color.Equals("1"))
                 {
-                    Console.ForegroundColor = ConsoleColor.Blue;
+                    Color.SetTextColor("1");
                 }
                 else if (color.Equals("2"))
                 {
-                    Console.ForegroundColor = ConsoleColor.Green;
+                    Color.SetTextColor("2");
                 }
                 else if (color.Equals("3"))
                 {
-                    Console.ForegroundColor = ConsoleColor.DarkBlue;
+                    Color.SetTextColor("3");
                 }
                 else if (color.Equals("4"))
                 {
-                    Console.ForegroundColor = ConsoleColor.Red;
+                    Color.SetTextColor("4");
                 }
                 else if (color.Equals("5"))
                 {
-                    Console.ForegroundColor = ConsoleColor.Magenta;
+                    Color.SetTextColor("5");
                 }
                 else if (color.Equals("6"))
                 {
-                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    Color.SetTextColor("6");
                 }
                 else if (color.Equals("7"))
                 {
-                    Console.ForegroundColor = ConsoleColor.White;
+                    Color.SetTextColor("7");
+                }
+                else
+                {
+                    L.Text.Display("unknowncolor");
+                }
+            }
+            else if (cmd.Equals("backgroundcolor"))
+            {
+                L.Color.Display();
+            }
+            else if (cmd.StartsWith("backgroundcolor "))
+            {
+                string color = cmd.Remove(0, 16);
+                if (color.Equals("0"))
+                {
+                    Color.SetBackgroundColor("0");
+                }
+                else if (color.Equals("1"))
+                {
+                    Color.SetBackgroundColor("1");
+                }
+                else if (color.Equals("2"))
+                {
+                    Color.SetBackgroundColor("2");
+                }
+                else if (color.Equals("3"))
+                {
+                    Color.SetBackgroundColor("3");
+                }
+                else if (color.Equals("4"))
+                {
+                    Color.SetBackgroundColor("4");
+                }
+                else if (color.Equals("5"))
+                {
+                    Color.SetBackgroundColor("5");
+                }
+                else if (color.Equals("6"))
+                {
+                    Color.SetBackgroundColor("6");
+                }
+                else if (color.Equals("7"))
+                {
+                    Color.SetBackgroundColor("7");
                 }
                 else
                 {
@@ -290,5 +348,7 @@ namespace Alve_OS.Shell
                 Console.ForegroundColor = ConsoleColor.White;
             }
         }
+
+        
     }
 }

--- a/Alve Operating System/Alve OS/System/Computer/Color.cs
+++ b/Alve Operating System/Alve OS/System/Computer/Color.cs
@@ -113,7 +113,7 @@ namespace Alve_OS.System.Computer
 
         }
 
-        public static void GetBackgroundTextColor(string defaultcolor = "7")
+        public static void GetBackgroundColor(string defaultcolor = "0")
         {
             if (File.Exists(@"0:\System\backcolor.set"))
             {
@@ -166,7 +166,7 @@ namespace Alve_OS.System.Computer
             if (File.Exists(@"0:\System\backcolor.set"))
             {
                 File.WriteAllText(@"0:\System\backcolor.set", color);
-                GetTextColor();
+                GetBackgroundColor();
             }
             else
             {

--- a/Alve Operating System/Alve OS/System/Computer/Color.cs
+++ b/Alve Operating System/Alve OS/System/Computer/Color.cs
@@ -1,0 +1,179 @@
+﻿using Alve_OS.System.Translation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Alve_OS.System.Computer
+{
+    class Color
+    {
+
+        public static void DisplayTextColor(string color = "7")
+        {
+
+            if (color.Equals("0"))
+            {
+                Console.ForegroundColor = ConsoleColor.Black;
+            }
+            else if (color.Equals("1"))
+            {
+                Console.ForegroundColor = ConsoleColor.Blue;
+            }
+            else if (color.Equals("2"))
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+            }
+            else if (color.Equals("3"))
+            {
+                Console.ForegroundColor = ConsoleColor.DarkBlue;
+            }
+            else if (color.Equals("4"))
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+            }
+            else if (color.Equals("5"))
+            {
+                Console.ForegroundColor = ConsoleColor.Magenta;
+            }
+            else if (color.Equals("6"))
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+            }
+            else if (color.Equals("7"))
+            {
+                Console.ForegroundColor = ConsoleColor.White;
+            }
+            else
+            {
+                Text.Display("unknowncolor");
+            }
+        }
+
+        public static void GetTextColor(string defaultcolor = "7")
+        {
+            if (File.Exists(@"0:\System\color.set"))
+            {
+                string color = File.ReadAllText(@"0:\System\color.set");
+
+                File.WriteAllText(@"0:\System\color.set", color);
+
+                if (color.Equals("0"))
+                {
+                    Console.ForegroundColor = ConsoleColor.Black;
+                }
+                else if (color.Equals("1"))
+                {
+                    Console.ForegroundColor = ConsoleColor.Blue;
+                }
+                else if (color.Equals("2"))
+                {
+                    Console.ForegroundColor = ConsoleColor.Green;
+                }
+                else if (color.Equals("3"))
+                {
+                    Console.ForegroundColor = ConsoleColor.DarkBlue;
+                }
+                else if (color.Equals("4"))
+                {
+                    Console.ForegroundColor = ConsoleColor.Red;
+                }
+                else if (color.Equals("5"))
+                {
+                    Console.ForegroundColor = ConsoleColor.Magenta;
+                }
+                else if (color.Equals("6"))
+                {
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                }
+                else if (color.Equals("7"))
+                {
+                    Console.ForegroundColor = ConsoleColor.White;
+                }
+            }
+            else
+            {
+                File.Create(@"0:\System\color.set");
+                File.WriteAllText(@"0:\System\color.set", defaultcolor);
+            }
+        }
+
+        public static void SetTextColor(string color = "7")
+        {
+            if (File.Exists(@"0:\System\color.set"))
+            {
+                File.WriteAllText(@"0:\System\color.set", color);
+                GetTextColor();
+            }
+            else
+            {
+                File.Create(@"0:\System\color.set");
+                File.WriteAllText(@"0:\System\color.set", color);
+            }
+
+        }
+
+        public static void GetBackgroundTextColor(string defaultcolor = "7")
+        {
+            if (File.Exists(@"0:\System\backcolor.set"))
+            {
+                string color = File.ReadAllText(@"0:\System\backcolor.set");
+
+                File.WriteAllText(@"0:\System\backcolor.set", color);
+
+                if (color.Equals("0"))
+                {
+                    Console.BackgroundColor = ConsoleColor.Black;
+                }
+                else if (color.Equals("1"))
+                {
+                    Console.BackgroundColor = ConsoleColor.Blue;
+                }
+                else if (color.Equals("2"))
+                {
+                    Console.BackgroundColor = ConsoleColor.Green;
+                }
+                else if (color.Equals("3"))
+                {
+                    Console.BackgroundColor = ConsoleColor.DarkBlue;
+                }
+                else if (color.Equals("4"))
+                {
+                    Console.BackgroundColor = ConsoleColor.Red;
+                }
+                else if (color.Equals("5"))
+                {
+                    Console.BackgroundColor = ConsoleColor.Magenta;
+                }
+                else if (color.Equals("6"))
+                {
+                    Console.BackgroundColor = ConsoleColor.Yellow;
+                }
+                else if (color.Equals("7"))
+                {
+                    Console.BackgroundColor = ConsoleColor.White;
+                }
+            }
+            else
+            {
+                File.Create(@"0:\System\backcolor.set");
+                File.WriteAllText(@"0:\System\backcolor.set", defaultcolor);
+            }
+        }
+
+        public static void SetBackgroundColor(string color = "0")
+        {
+            if (File.Exists(@"0:\System\backcolor.set"))
+            {
+                File.WriteAllText(@"0:\System\backcolor.set", color);
+                GetTextColor();
+            }
+            else
+            {
+                File.Create(@"0:\System\backcolor.set");
+                File.WriteAllText(@"0:\System\backcolor.set", color);
+            }
+
+        }
+    }
+}

--- a/Alve Operating System/Alve OS/System/Computer/Info.cs
+++ b/Alve Operating System/Alve OS/System/Computer/Info.cs
@@ -10,7 +10,15 @@ namespace Alve_OS.System.Computer
 
         public static string getComputerName()
         {
-            return File.ReadAllText(@"0:\System\computer.nam");
+            try
+            {
+                return File.ReadAllText(@"0:\System\computer.nam");
+            }
+            catch
+            {
+                AskComputerName();
+                return "Alve-PC";
+            }
         }
 
         public static void setComputerName(string name)

--- a/Alve Operating System/Alve OS/System/Computer/Info.cs
+++ b/Alve Operating System/Alve OS/System/Computer/Info.cs
@@ -1,4 +1,9 @@
-﻿
+﻿/*
+* PROJECT:          Alve Operating System Development
+* CONTENT:          Computer Information
+* PROGRAMMERS:      Alexy DA CRUZ <dacruzalexy@gmail.com>
+*/
+
 using System.IO;
 using System;
 using Alve_OS.System.Translation;
@@ -7,7 +12,10 @@ namespace Alve_OS.System.Computer
 {
     class Info
     {
-
+        /// <summary>
+        /// Méthode pour récupérer le nom de l'ordinateur.
+        /// </summary>
+        /// <returns></returns>
         public static string getComputerName()
         {
             try
@@ -16,11 +24,15 @@ namespace Alve_OS.System.Computer
             }
             catch
             {
-                AskComputerName();
+                setComputerName("Alve-PC");
                 return "Alve-PC";
             }
         }
 
+        /// <summary>
+        /// Méthode pour appliquer un nom pour l'ordinateur.
+        /// </summary>
+        /// <param name="name"></param>
         public static void setComputerName(string name)
         {
             if (File.Exists(@"0:\System\computer.nam"))
@@ -35,6 +47,9 @@ namespace Alve_OS.System.Computer
             }
         }
 
+        /// <summary>
+        /// Méthode pour demander à l'utilisateur un nom pour l'ordinateur.
+        /// </summary>
         public static void AskComputerName()
         {
             Console.WriteLine();

--- a/Alve Operating System/Alve OS/System/Computer/Info.cs
+++ b/Alve Operating System/Alve OS/System/Computer/Info.cs
@@ -1,0 +1,59 @@
+﻿
+using System.IO;
+using System;
+using Alve_OS.System.Translation;
+
+namespace Alve_OS.System.Computer
+{
+    class Info
+    {
+
+        public static string getComputerName()
+        {
+            return File.ReadAllText(@"0:\System\computer.nam");
+        }
+
+        public static void setComputerName(string name)
+        {
+            if (File.Exists(@"0:\System\computer.nam"))
+            {
+                File.WriteAllText(@"0:\System\computer.nam", name);
+            }
+            else
+            {
+                File.Create(@"0:\System\computer.nam");
+                File.WriteAllText(@"0:\System\computer.nam", name);
+
+            }
+        }
+
+        public static void AskComputerName()
+        {
+            Console.WriteLine();
+            Text.Display("askcomputername");
+            Console.WriteLine();
+            Text.Display("computernamename");
+            var computername = Console.ReadLine();
+
+            if((computername.Length >= 1) && (computername.Length <= 15)) //15 char max for NETBIOS name resolution (dns)
+            {
+                setComputerName(computername);
+                Console.WriteLine();
+
+                Text.Display("computernamesuccess");
+                Console.WriteLine();
+            }
+            else
+            {
+                Text.Display("computernameincorrect");
+                Console.WriteLine();
+                AskComputerName();
+            }
+
+            
+        }
+
+        
+
+    }
+}

--- a/Alve Operating System/Alve OS/System/Computer/Info.cs
+++ b/Alve Operating System/Alve OS/System/Computer/Info.cs
@@ -18,11 +18,12 @@ namespace Alve_OS.System.Computer
         /// <returns></returns>
         public static string getComputerName()
         {
-            try
+            if (File.Exists(@"0:\System\computer.nam"))
             {
-                return File.ReadAllText(@"0:\System\computer.nam");
+                Kernel.ComputerName = File.ReadAllText(@"0:\System\computer.nam");
+                return Kernel.ComputerName;
             }
-            catch
+            else
             {
                 setComputerName("Alve-PC");
                 return "Alve-PC";
@@ -37,6 +38,8 @@ namespace Alve_OS.System.Computer
         {
             if (File.Exists(@"0:\System\computer.nam"))
             {
+                File.Delete(@"0:\System\computer.nam");
+                File.Create(@"0:\System\computer.nam");
                 File.WriteAllText(@"0:\System\computer.nam", name);
             }
             else

--- a/Alve Operating System/Alve OS/System/Setup.cs
+++ b/Alve Operating System/Alve OS/System/Setup.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using L = Alve_OS.System.Translation;
 using Alve_OS.System.Security;
+using Alve_OS.System.Computer;
 
 namespace Alve_OS.System
 {
@@ -83,6 +84,8 @@ namespace Alve_OS.System
                 {
                     Directory.CreateDirectory(@"0:\Users\root");
                 }
+
+                Info.setComputerName("Alve-PC");
 
                 if ((Directory.Exists(@"0:\System")) && (Directory.Exists(@"0:\System\Users")) && (Directory.Exists(@"0:\Users")) && (Directory.Exists(@"0:\Users\root")))
                 {
@@ -209,9 +212,50 @@ namespace Alve_OS.System
 
 
         /// <summary>
-        /// Méthode permettant de valider l'installation.
+        /// Demande du nom pour l'ordinateur
         /// </summary>
         private void Step5()
+        {
+            try
+            {
+                Console.Clear();
+                Logo.Print();
+                AskComputerName();
+            }
+            catch
+            {
+                ErrorDuringSetup("Computer Name");
+            }
+        }
+
+        private void AskComputerName()
+        {
+            Console.WriteLine();
+            L.Text.Display("askcomputername");
+            Console.WriteLine();
+            L.Text.Display("computernamename");
+            var computername = Console.ReadLine();
+
+            if ((computername.Length >= 1) && (computername.Length <= 15)) //15 char max for NETBIOS name resolution (dns)
+            {
+                Info.setComputerName(computername);
+                Step6();
+            }
+            else
+            {
+                L.Text.Display("computernameincorrect");
+                Console.WriteLine();
+                AskComputerName();
+            }
+
+
+        }
+
+
+        /// <summary>
+        /// Méthode permettant de valider l'installation.
+        /// </summary>
+        private void Step6()
         {
             File.Create(@"0:\System\setup");
             Console.Clear();

--- a/Alve Operating System/Alve OS/System/Setup.cs
+++ b/Alve Operating System/Alve OS/System/Setup.cs
@@ -23,7 +23,7 @@ namespace Alve_OS.System
         {
             try
             {
-                if (!File.Exists(@"0:\System\setup"))
+                if (!File.Exists(@"0:\System\setup.set"))
                 {
                     StartSetup();
                 }
@@ -83,6 +83,12 @@ namespace Alve_OS.System
                 if (!Directory.Exists(@"0:\Users\root"))
                 {
                     Directory.CreateDirectory(@"0:\Users\root");
+                }
+
+                if (!File.Exists(@"0:\System\color.set"))
+                {
+                    File.Create(@"0:\System\color.set");
+                    File.WriteAllText(@"0:\System\color.set", "7");
                 }
 
                 Info.setComputerName("Alve-PC");
@@ -154,11 +160,11 @@ namespace Alve_OS.System
                 Kernel.langSelected = "en_US";
                 L.Keyboard.Init();
 
-                File.Create(@"0:\System\lang");
+                File.Create(@"0:\System\lang.set");
 
-                if (File.Exists(@"0:\System\lang"))
+                if (File.Exists(@"0:\System\lang.set"))
                 {
-                    File.WriteAllText(@"0:\System\lang", Kernel.langSelected);
+                    File.WriteAllText(@"0:\System\lang.set", Kernel.langSelected);
                 }
                 else
                 {
@@ -172,11 +178,11 @@ namespace Alve_OS.System
                 Kernel.langSelected = "fr_FR";
                 L.Keyboard.Init();
 
-                File.Create(@"0:\System\lang");
+                File.Create(@"0:\System\lang.set");
 
-                if (File.Exists(@"0:\System\lang"))
+                if (File.Exists(@"0:\System\lang.set"))
                 {
-                    File.WriteAllText(@"0:\System\lang", Kernel.langSelected);
+                    File.WriteAllText(@"0:\System\lang.set", Kernel.langSelected);
                 }
                 else
                 {
@@ -257,7 +263,7 @@ namespace Alve_OS.System
         /// </summary>
         private void Step6()
         {
-            File.Create(@"0:\System\setup");
+            File.Create(@"0:\System\setup.set");
             Console.Clear();
         }
 

--- a/Alve Operating System/Alve OS/System/Translation/Text/Help.cs
+++ b/Alve Operating System/Alve OS/System/Translation/Text/Help.cs
@@ -23,6 +23,7 @@ namespace Alve_OS.System.Translation
                     Console.WriteLine("- cd .. (Pour naviguer dans l'arborescence)");
                     Console.WriteLine("- cd (Pour aller à un dossier)");
                     Console.WriteLine("- dir (Liste les fichiers et dossiers)");
+                    Console.WriteLine("- ls (Liste les fichiers et dossiers)");
                     Console.WriteLine("- mkdir (Pour créer un dossier)");
                     Console.WriteLine("- rmdir (Pour supprimer un dossier)");
                     Console.WriteLine("- mkfil (Pour créer un fichier)");
@@ -33,7 +34,8 @@ namespace Alve_OS.System.Translation
                     Console.WriteLine("- systeminfo (Affiche des informations systeme)");
                     Console.WriteLine("- langset (Changer le langage système)");
                     Console.WriteLine("- ver (Pour afficher la version système)");
-                    Console.WriteLine("- color (Permet de changer la couleur de premier plan)");
+                    Console.WriteLine("- textcolor (Permet de changer la couleur de premier plan)");
+                    Console.WriteLine("- backgroundcolor (Permet de changer la couleur de dernier plan)");
                     Console.WriteLine("- settings {args} (Permet d'accéder aux paramètres)");
                     Console.WriteLine("- logout (Permet de se déconnecter)");
                     break;
@@ -46,6 +48,7 @@ namespace Alve_OS.System.Translation
                     Console.WriteLine("- cd .. (to navigate to the parent folder)");
                     Console.WriteLine("- cd (to navigate to a folder)");
                     Console.WriteLine("- dir (to list directories and files)");
+                    Console.WriteLine("- ls (to list directories and files)");
                     Console.WriteLine("- mkdir (to create a directory");
                     Console.WriteLine("- rmdir (to remove a directory)");
                     Console.WriteLine("- mkfil (to create a file)");
@@ -56,7 +59,8 @@ namespace Alve_OS.System.Translation
                     Console.WriteLine("- systeminfo (to display system informations)");
                     Console.WriteLine("- langset (to change system language)");
                     Console.WriteLine("- ver (to display system version)");
-                    Console.WriteLine("- color (change foreground colour)");
+                    Console.WriteLine("- textcolor (change foreground colour)");
+                    Console.WriteLine("- backgroundcolor (change background colour)");
                     Console.WriteLine("- settings {args} (Access to settings)");
                     Console.WriteLine("- logout (To disconnect)");
                     break;
@@ -69,12 +73,14 @@ namespace Alve_OS.System.Translation
             {
                 case "fr_FR":
                     Console.WriteLine("Commandes disponible:");
-                    Console.WriteLine("- adduser (Gestion des utilisateurs)");
+                    Console.WriteLine("- adduser (Pour créer un compte)");
+                    Console.WriteLine("- setcomputername (Nom de l'ordinateur)");
                     break;
 
                 case "en_US":
                     Console.WriteLine("Available commands:");
-                    Console.WriteLine("- adduser (Users manager)");
+                    Console.WriteLine("- adduser (To create an account)");
+                    Console.WriteLine("- setcomputername (Computer name)");
                     break;
             }
         }

--- a/Alve Operating System/Alve OS/System/Translation/Text/Text.cs
+++ b/Alve Operating System/Alve OS/System/Translation/Text/Text.cs
@@ -135,7 +135,7 @@ namespace Alve_OS.System.Translation
                             Console.Write("Nom de l'ordinateur > ");
                             break;
                         case "computernamesuccess":
-                            Console.Write("Le nouveau nom de l'ordinateur a été appliqué !");
+                            Console.Write("Le nouveau nom de l'ordinateur a été appliqué ! \n\nRedémarrez l'ordinateur pour que le changement prenne effet.");
                             break;
                         case "tips":
                             Console.WriteLine(" * Conseil(s) :");
@@ -255,7 +255,7 @@ namespace Alve_OS.System.Translation
                             Console.Write("Computer name > ");
                             break;
                         case "computernamesuccess":
-                            Console.Write("The new computer name has been applied!");
+                            Console.Write("The new computer name has been applied! \n\nReboot the computer for the changing name take effect.");
                             break;
                         case "tips":
                             Console.WriteLine(" * Tips :");

--- a/Alve Operating System/Alve OS/System/Translation/Text/Text.cs
+++ b/Alve Operating System/Alve OS/System/Translation/Text/Text.cs
@@ -41,9 +41,6 @@ namespace Alve_OS.System.Translation
                         case "directorydoesntexist":
                             Console.WriteLine("Ce répertoire n'éxiste pas !");
                             break;
-                        case "typename":
-                            Console.WriteLine("Type\t Nom");
-                            break;
                         case "doesnotexist":
                             Console.WriteLine(arg + " n'existe pas !");
                             break;
@@ -140,6 +137,12 @@ namespace Alve_OS.System.Translation
                         case "computernamesuccess":
                             Console.Write("Le nouveau nom de l'ordinateur a été appliqué !");
                             break;
+                        case "tips":
+                            Console.WriteLine(" * Conseil(s) :");
+                            break;
+                        case "foldercontent":
+                            Console.WriteLine("Contenu du dossier '" + arg + "':");
+                            break;
 
                     }
                     break;
@@ -160,9 +163,6 @@ namespace Alve_OS.System.Translation
                             break;
                         case "directorydoesntexist":
                             Console.WriteLine("This directory doesn't exist!");
-                            break;
-                        case "typename":
-                            Console.WriteLine("Type\t Name");
                             break;
                         case "doesnotexist":
                             Console.WriteLine(arg + " does not exist!");
@@ -256,6 +256,12 @@ namespace Alve_OS.System.Translation
                             break;
                         case "computernamesuccess":
                             Console.Write("The new computer name has been applied!");
+                            break;
+                        case "tips":
+                            Console.WriteLine(" * Tips :");
+                            break;
+                        case "foldercontent":
+                            Console.WriteLine("Folder's content of '" + arg + "':");
                             break;
                     }
                     break;

--- a/Alve Operating System/Alve OS/System/Translation/Text/Text.cs
+++ b/Alve Operating System/Alve OS/System/Translation/Text/Text.cs
@@ -128,6 +128,19 @@ namespace Alve_OS.System.Translation
                         case "wrongpassword":
                             Console.WriteLine("Mauvais mot de passe.");
                             break;
+                        case "askcomputername":
+                            Console.WriteLine("Choisissez le nom pour votre ordinateur :");
+                            break;
+                        case "computernameincorrect":
+                            Console.WriteLine("Le nom de l'ordinateur est incorrect, il doit être composé au maximum de 15 caractères.");
+                            break;
+                        case "computernamename":
+                            Console.Write("Nom de l'ordinateur > ");
+                            break;
+                        case "computernamesuccess":
+                            Console.Write("Le nouveau nom de l'ordinateur a été appliqué !");
+                            break;
+
                     }
                     break;
 
@@ -231,6 +244,18 @@ namespace Alve_OS.System.Translation
                             break;
                         case "wrongpassword":
                             Console.WriteLine("Wrong Password.");
+                            break;
+                        case "askcomputername":
+                            Console.WriteLine("Choose your computer name :");
+                            break;
+                        case "computernameincorrect":
+                            Console.WriteLine("The computer name is incorrect, computer name length should be 1-20 characters.");
+                            break;
+                        case "computernamename":
+                            Console.Write("Computer name > ");
+                            break;
+                        case "computernamesuccess":
+                            Console.Write("The new computer name has been applied!");
                             break;
                     }
                     break;

--- a/Alve Operating System/Alve OS/System/Users/UserLevel.cs
+++ b/Alve Operating System/Alve OS/System/Users/UserLevel.cs
@@ -32,7 +32,7 @@ namespace Alve_OS.System.Users
             }
             else
             {
-                return "@";
+                return "$";
             }
         }
 

--- a/Alve Operating System/Alve OS/System/Users/UserLevel.cs
+++ b/Alve Operating System/Alve OS/System/Users/UserLevel.cs
@@ -13,17 +13,28 @@ namespace Alve_OS.System.Users
 {
     class UserLevel
     {
-
+        /// <summary>
+        /// Administrateur
+        /// </summary>
+        /// <returns></returns>
         public static string Administrator()
         {
             return "admin";
         }
 
+        /// <summary>
+        /// Standard
+        /// </summary>
+        /// <returns>standard</returns>
         public static string StandardUser()
         {
             return "standard";
         }
 
+        /// <summary>
+        /// Type d'utilisateur
+        /// </summary>
+        /// <returns>Le caractère correspondant au type d'utilisateur</returns>
         public static string TypeUser()
         {
             if(Kernel.userLevelLogged == Administrator())

--- a/Alve Operating System/Alve OS/System/WelcomeMessage.cs
+++ b/Alve Operating System/Alve OS/System/WelcomeMessage.cs
@@ -8,6 +8,8 @@
 using System;
 using System.IO;
 using Alve_OS.System.Security;
+using Alve_OS.System.Computer;
+using Alve_OS.System.Translation;
 
 namespace Alve_OS.System
 {
@@ -26,16 +28,33 @@ namespace Alve_OS.System
                     Console.ForegroundColor = ConsoleColor.Green;
                     Console.WriteLine(" * Documentation: github.com/Alve-OS/Alve-Operating-System/wiki");
                     Console.ForegroundColor = ConsoleColor.White;
-                    if (File.Exists(@"0:\Users\root.usr"))
+
+                    if ((File.Exists(@"0:\System\Users\root.usr")) || (Info.getComputerName() == "Alve-PC"))
                     {
-                        string RootPassword = File.ReadAllText(@"0:\System\Users\root.usr");
-                        if (RootPassword == MD5.hash("root"))
+                        Console.WriteLine();
+                        Text.Display("tips");
+
+                        if (File.Exists(@"0:\System\Users\root.usr"))
+                        {
+                            string RootPassword = File.ReadAllText(@"0:\System\Users\root.usr");
+                            if (RootPassword == MD5.hash("root" + "|admin"))
+                            {
+                                Console.WriteLine(" ");
+                                Console.ForegroundColor = ConsoleColor.Blue;
+                                Console.WriteLine("   - Le mot de passe par défaut pour le compte root est 'root'");
+                                Console.ForegroundColor = ConsoleColor.White;
+                            }
+                        }
+
+                        if (Info.getComputerName() == "Alve-PC")
                         {
                             Console.WriteLine(" ");
                             Console.ForegroundColor = ConsoleColor.Blue;
-                            Console.WriteLine("* Le mot de passe par défaut pour le compte root est 'root'");
+                            Console.WriteLine("   - Le nom de l'ordinateur est 'Alve-PC', pensez à le changer.");
                             Console.ForegroundColor = ConsoleColor.White;
                         }
+
+                        
                     }
                     Console.WriteLine(" ");
                     break;
@@ -45,15 +64,30 @@ namespace Alve_OS.System
                     Console.ForegroundColor = ConsoleColor.Green;
                     Console.WriteLine(" * Documentation: github.com/Alve-OS/Alve-Operating-System/wiki");
                     Console.ForegroundColor = ConsoleColor.White;
-                    if (File.Exists("0:\\Users\\root.usr"))
+                    if ((File.Exists(@"0:\System\Users\root.usr")) || (Info.getComputerName() == "Alve-PC"))
                     {
-                        string RootPassword = File.ReadAllText("0:\\Users\\root.usr");
-                        if (RootPassword == "root")
+                        Console.WriteLine();
+                        Text.Display("tips");
+
+                        if (File.Exists(@"0:\System\Users\root.usr"))
                         {
-                            Console.WriteLine(" ");
-                            Console.ForegroundColor = ConsoleColor.Blue;
-                            Console.WriteLine("   * Default password for root is 'root'");
-                            Console.ForegroundColor = ConsoleColor.White;
+                            string RootPassword = File.ReadAllText(@"0:\System\Users\root.usr");
+                            if (RootPassword == MD5.hash("root" + "|admin"))
+                            {
+                                Console.WriteLine(" ");
+                                Console.ForegroundColor = ConsoleColor.Blue;
+                                Console.WriteLine("   * Default password for root is 'root'");
+                                Console.ForegroundColor = ConsoleColor.White;
+                            }
+
+                            if (Info.getComputerName() == "Alve-PC")
+                            {
+                                Console.WriteLine(" ");
+                                Console.ForegroundColor = ConsoleColor.Blue;
+                                Console.WriteLine("   - Computer name is 'Alve-PC', think to change it.");
+                                Console.ForegroundColor = ConsoleColor.White;
+                            }
+
                         }
                     }
                     Console.WriteLine(" ");

--- a/Alve Operating System/Alve OS/System/WelcomeMessage.cs
+++ b/Alve Operating System/Alve OS/System/WelcomeMessage.cs
@@ -29,15 +29,17 @@ namespace Alve_OS.System
                     Console.WriteLine(" * Documentation: github.com/Alve-OS/Alve-Operating-System/wiki");
                     Console.ForegroundColor = ConsoleColor.White;
 
-                    if ((File.Exists(@"0:\System\Users\root.usr")) || (Info.getComputerName() == "Alve-PC"))
+                    if ((File.ReadAllText(@"0:\System\Users\root.usr") == MD5.hash("root") + "|admin") || (Info.getComputerName() == "Alve-PC"))
                     {
                         Console.WriteLine();
+
+                        Console.ForegroundColor = ConsoleColor.Green;
                         Text.Display("tips");
 
                         if (File.Exists(@"0:\System\Users\root.usr"))
                         {
                             string RootPassword = File.ReadAllText(@"0:\System\Users\root.usr");
-                            if (RootPassword == MD5.hash("root" + "|admin"))
+                            if (RootPassword == MD5.hash("root") + "|admin")
                             {
                                 Console.WriteLine(" ");
                                 Console.ForegroundColor = ConsoleColor.Blue;
@@ -64,9 +66,12 @@ namespace Alve_OS.System
                     Console.ForegroundColor = ConsoleColor.Green;
                     Console.WriteLine(" * Documentation: github.com/Alve-OS/Alve-Operating-System/wiki");
                     Console.ForegroundColor = ConsoleColor.White;
-                    if ((File.Exists(@"0:\System\Users\root.usr")) || (Info.getComputerName() == "Alve-PC"))
+
+                    if ((File.ReadAllText(@"0:\System\Users\root.usr") == MD5.hash("root") + "|admin") || (Info.getComputerName() == "Alve-PC"))
                     {
                         Console.WriteLine();
+
+                        Console.ForegroundColor = ConsoleColor.Green;
                         Text.Display("tips");
 
                         if (File.Exists(@"0:\System\Users\root.usr"))
@@ -74,6 +79,7 @@ namespace Alve_OS.System
                             string RootPassword = File.ReadAllText(@"0:\System\Users\root.usr");
                             if (RootPassword == MD5.hash("root" + "|admin"))
                             {
+                                
                                 Console.WriteLine(" ");
                                 Console.ForegroundColor = ConsoleColor.Blue;
                                 Console.WriteLine("   * Default password for root is 'root'");
@@ -82,6 +88,7 @@ namespace Alve_OS.System
 
                             if (Info.getComputerName() == "Alve-PC")
                             {
+                                
                                 Console.WriteLine(" ");
                                 Console.ForegroundColor = ConsoleColor.Blue;
                                 Console.WriteLine("   - Computer name is 'Alve-PC', think to change it.");


### PR DESCRIPTION
# Big Update (Computer name, BeforeCommand...)

## Features
- [x]  Nouvelle étape durant le setup pour la demande de nom. 
- [x]  Conseil de changer le nom de pc si l'utilisateur n'en possède pas et qu'il a déjà installé Alve.
- [x] Commande pour mettre un nom. (settings setcomputername)
- [x] Affiche le nom dans le BeforeCommand()
- [x]  Bug fixes des couleurs suite au BeforeCommand() et autre.
- [x]  Sauvegarde de la couleur du texte ainsi que de fond.
- [x]  Nouvel explorateur de fichiers, s'apparente plus à Ubuntu.
- [x]  Nomenclature concernant les fichiers systèmes: ".set" pour les paramètres, ".usr" pour les fichiers utilisateurs, ".nam" pour le sauvegarde de noms.
- [x]  Nouvelle commandes concernant les couleurs pour une meilleure utilisation des développeurs ainsi que les utilisateurs lors de l'utilisation d'Alve.
- [x] Commande ls
- [x] Command dir/ls + folder (ex: ls 0:\System\thing")
- [x] Fix tips root password
- [x] Tips

## BeforeCommand():
* Méthode pour personnalisé ce qu'il y a avant la commande.