### PR TITLE
Filesystem Update

### DIFF
--- a/Alve Operating System/Alve OS/Alve_OSBoot.Cosmos
+++ b/Alve Operating System/Alve OS/Alve_OSBoot.Cosmos
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <BinFormat>elf</BinFormat>
     <Profile>VMware</Profile>
-    <DebugEnabled>True</DebugEnabled>
+    <DebugEnabled>False</DebugEnabled>
     <DebugMode>Source</DebugMode>
     <TraceMode>User</TraceMode>
     <EnableGDB>False</EnableGDB>
@@ -20,7 +20,7 @@
     <VMware_Description>Use VMware Player or Workstation to deploy and debug.</VMware_Description>
     <VMware_Deployment>ISO</VMware_Deployment>
     <VMware_Launch>VMware</VMware_Launch>
-    <VMware_DebugEnabled>True</VMware_DebugEnabled>
+    <VMware_DebugEnabled>False</VMware_DebugEnabled>
     <VMware_DebugMode>Source</VMware_DebugMode>
     <VMware_VisualStudioDebugPort>Pipe: Cosmos\Serial</VMware_VisualStudioDebugPort>
     <VMware_PxeInterface>192.168.68.1</VMware_PxeInterface>

--- a/Alve Operating System/Alve OS/Shell/DirectoryListing.cs
+++ b/Alve Operating System/Alve OS/Shell/DirectoryListing.cs
@@ -11,7 +11,7 @@ namespace Alve_OS.Shell
 
         public static void DispDirectories(string directory)
         {
-            foreach (string dir in Directory.GetDirectories(Kernel.current_directory))
+            foreach (string dir in Directory.GetDirectories(directory))
             {
                 Color.DisplayTextColor("6");
                 Console.Write("\\" + dir + "\t");
@@ -20,7 +20,7 @@ namespace Alve_OS.Shell
 
         public static void DispFiles(string directory)
         {
-            foreach (string file in Directory.GetFiles(Kernel.current_directory))
+            foreach (string file in Directory.GetFiles(directory))
             {
                 Char formatDot = '.';
                 string[] ext = file.Split(formatDot);
@@ -45,7 +45,7 @@ namespace Alve_OS.Shell
 
         public static void DispHiddenFiles(string directory)
         {
-            foreach (string file in Directory.GetFiles(Kernel.current_directory))
+            foreach (string file in Directory.GetFiles(directory))
             {
                 Char formatDot = '.';
                 string[] ext = file.Split(formatDot);

--- a/Alve Operating System/Alve OS/Shell/DirectoryListing.cs
+++ b/Alve Operating System/Alve OS/Shell/DirectoryListing.cs
@@ -1,7 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
+﻿/*
+* PROJECT:          Alve Operating System Development
+* CONTENT:          Directory and files listing system.
+* PROGRAMMERS:      Alexy DA CRUZ <dacruzalexy@gmail.com>
+*                   Valentin Charbonnier <valentinbreiz@gmail.com>
+*/
+
+using System;
 using System.IO;
-using System.Text;
 using Alve_OS.System.Computer;
 
 namespace Alve_OS.Shell
@@ -99,6 +104,5 @@ namespace Alve_OS.Shell
 
             }
         }
-
     }
 }

--- a/Alve Operating System/Alve OS/Shell/DirectoryListing.cs
+++ b/Alve Operating System/Alve OS/Shell/DirectoryListing.cs
@@ -8,16 +8,39 @@ namespace Alve_OS.Shell
 {
     class DirectoryListing
     {
-
+        /// <summary>
+        /// Display directories of "directory"
+        /// </summary>
+        /// <param name="directory"></param>
         public static void DispDirectories(string directory)
         {
             foreach (string dir in Directory.GetDirectories(directory))
             {
-                Color.DisplayTextColor("6");
-                Console.Write("\\" + dir + "\t");
+                if (!dir.StartsWith("."))
+                {
+                    Color.DisplayTextColor("6");
+                    Console.Write(dir + "\t");
+                }
             }
         }
 
+        /// <summary>
+        /// Display hidden and normal directories of "directory"
+        /// </summary>
+        /// <param name="directory"></param>
+        public static void DispHiddenDirectories(string directory)
+        {
+            foreach (string dir in Directory.GetDirectories(directory))
+            {
+                Color.DisplayTextColor("6");
+                Console.Write(dir + "\t");
+            }
+        }
+
+        /// <summary>
+        /// Display files of "directory"
+        /// </summary>
+        /// <param name="directory"></param>
         public static void DispFiles(string directory)
         {
             foreach (string file in Directory.GetFiles(directory))
@@ -43,6 +66,10 @@ namespace Alve_OS.Shell
             }
         }
 
+        /// <summary>
+        /// Display hidden and normal files of "directory"
+        /// </summary>
+        /// <param name="directory"></param>
         public static void DispHiddenFiles(string directory)
         {
             foreach (string file in Directory.GetFiles(directory))

--- a/Alve Operating System/Alve OS/Shell/DirectoryListing.cs
+++ b/Alve Operating System/Alve OS/Shell/DirectoryListing.cs
@@ -30,11 +30,14 @@ namespace Alve_OS.Shell
         /// <param name="directory"></param>
         public static void DispHiddenDirectories(string directory)
         {
-            foreach (string dir in Directory.GetDirectories(directory))
-            {
-                Color.DisplayTextColor("6");
-                Console.Write(dir + "\t");
-            }
+            //foreach (string dir in Directory.GetDirectories(directory))
+            //{
+            //  Color.DisplayTextColor("6");
+            //  Console.Write(dir + "\t");
+            //}
+
+            throw new NotImplementedException();
+            //Cosmos doesn't support directories with a dot in it. :/ (FAT problem)
         }
 
         /// <summary>
@@ -77,9 +80,15 @@ namespace Alve_OS.Shell
                 Char formatDot = '.';
                 string[] ext = file.Split(formatDot);
                 string lastext = ext[ext.Length - 1];
+
                 if ((lastext == "set") || (lastext == "nam") || (lastext == "usr"))
                 {
                     Color.DisplayTextColor("4");
+                    Console.Write(file + "\t");
+                }
+                else if (file.StartsWith("."))
+                {
+                    Color.DisplayTextColor("5");
                     Console.Write(file + "\t");
                 }
                 else

--- a/Alve Operating System/Alve OS/Shell/Interpreter.cs
+++ b/Alve Operating System/Alve OS/Shell/Interpreter.cs
@@ -219,14 +219,14 @@ namespace Alve_OS.Shell
                 {
                     if (cmdargs[1].Equals("-a"))
                     {
-                        DirectoryListing.DispHiddenDirectories(Kernel.current_directory);
+                        DirectoryListing.DispDirectories(Kernel.current_directory);
                         DirectoryListing.DispHiddenFiles(Kernel.current_directory);
 
                         if (cmdargs.Length == 3)
                         {
                             directory = cmdargs[2];
 
-                            DirectoryListing.DispHiddenDirectories(Kernel.current_directory + directory);
+                            DirectoryListing.DispDirectories(Kernel.current_directory + directory);
                             DirectoryListing.DispHiddenFiles(Kernel.current_directory + directory);
                         }
                     }
@@ -238,18 +238,78 @@ namespace Alve_OS.Shell
 
             }
 
+            //create directory
             else if (cmd.StartsWith("mkdir "))
             {
                 string dir = cmd.Remove(0, 6);
-                if (!Directory.Exists(Kernel.current_directory + dir))
+
+                if (dir.Contains("."))
                 {
-                    Kernel.FS.CreateDirectory(Kernel.current_directory + dir);
+                    L.Text.Display("mkdirunsupporteddot");
+                    Console.WriteLine();
                 }
-                else if (Directory.Exists(Kernel.current_directory + dir))
+                else
                 {
-                    //normalement ça bug ici
-                    Kernel.FS.CreateDirectory(Kernel.current_directory + dir + "-1");
-                }
+                    if (!Directory.Exists(Kernel.current_directory + dir))
+                    {
+                        Directory.CreateDirectory(Kernel.current_directory + dir);
+                    }
+                    else if (Directory.Exists(Kernel.current_directory + dir))
+                    {
+                        Char[] separators = new char[] { '(', ')' };
+                        Char[] directories = new char[] { '/', '\\' };
+
+                        //getting last directory.
+                        string x1 = Kernel.current_directory + dir;
+                        string[] x2 = x1.Split(directories);
+                        string x3 = x2[x2.Length - 1];
+                        int x4 = 0;
+
+                        //boucle
+                        boucle:
+                        x4 = x4 + 1;
+                        string DirectoryAlreadyExist = x3 + "(" + x4 +")";
+
+                        //if directory has already been recreated once or more
+                        if ((DirectoryAlreadyExist.Contains("(")) && (DirectoryAlreadyExist.Contains(")")))
+                        {
+                            //get number
+                            string[] endName = DirectoryAlreadyExist.Split(separators);
+                            int num = int.Parse(endName[1]);
+
+                            //add one to num
+                            num = num + 1;
+
+                            //set new directory name with the new number.
+                            string newName = dir + "(" + num + ")";
+
+                            if(Directory.Exists(Kernel.current_directory + newName))
+                            {                                
+                                goto boucle;
+                            }
+
+                            //create directory
+                            Directory.CreateDirectory(Kernel.current_directory + newName);
+
+                            //display text to inform the user that the directory has been created with an another name
+                            Console.WriteLine();
+                            Console.ForegroundColor = ConsoleColor.Yellow;
+                            L.Text.Display("mkdirfilealreadyexist", newName);
+                            Console.WriteLine();
+                        }
+                        else
+                        {
+                            //if not, we create directory with (1)
+                            Directory.CreateDirectory(Kernel.current_directory + dir + "(1)");
+
+                            //display text to inform the user that the directory has been created with an another name
+                            Console.WriteLine();
+                            Console.ForegroundColor = ConsoleColor.Yellow;
+                            L.Text.Display("mkdirfilealreadyexist", dir + "(1)");
+                            Console.WriteLine();
+                        }
+                    }
+                }                
             }
 
             else if (cmd.StartsWith("rmdir "))
@@ -276,6 +336,11 @@ namespace Alve_OS.Shell
                 {
                     L.Text.Display("doesnotexist");
                 }
+            }
+
+            else if (cmd.Equals("mkdir"))
+            {
+                L.Text.Display("mkdir");
             }
 
             else if (cmd.Equals("mkfil"))

--- a/Alve Operating System/Alve OS/Shell/Interpreter.cs
+++ b/Alve Operating System/Alve OS/Shell/Interpreter.cs
@@ -194,6 +194,7 @@ namespace Alve_OS.Shell
             {
                 DirectoryListing.DispDirectories(Kernel.current_directory);
                 DirectoryListing.DispFiles(Kernel.current_directory);
+                Console.WriteLine();
             }
 
             else if ((cmd.StartsWith("dir ")) || (cmd.StartsWith("ls ")))
@@ -232,10 +233,10 @@ namespace Alve_OS.Shell
                     }
                     else
                     {
-                        Console.WriteLine("cet argument est invalide");
+                        L.Text.Display("invalidargument");
                     }
                 }
-
+                Console.WriteLine();
             }
 
             //create directory
@@ -246,7 +247,6 @@ namespace Alve_OS.Shell
                 if (dir.Contains("."))
                 {
                     L.Text.Display("mkdirunsupporteddot");
-                    Console.WriteLine();
                 }
                 else
                 {
@@ -292,10 +292,8 @@ namespace Alve_OS.Shell
                             Directory.CreateDirectory(Kernel.current_directory + newName);
 
                             //display text to inform the user that the directory has been created with an another name
-                            Console.WriteLine();
                             Console.ForegroundColor = ConsoleColor.Yellow;
                             L.Text.Display("mkdirfilealreadyexist", newName);
-                            Console.WriteLine();
                         }
                         else
                         {
@@ -303,10 +301,8 @@ namespace Alve_OS.Shell
                             Directory.CreateDirectory(Kernel.current_directory + dir + "(1)");
 
                             //display text to inform the user that the directory has been created with an another name
-                            Console.WriteLine();
                             Console.ForegroundColor = ConsoleColor.Yellow;
                             L.Text.Display("mkdirfilealreadyexist", dir + "(1)");
-                            Console.WriteLine();
                         }
                     }
                 }                

--- a/Alve Operating System/Alve OS/Shell/Interpreter.cs
+++ b/Alve Operating System/Alve OS/Shell/Interpreter.cs
@@ -41,7 +41,7 @@ namespace Alve_OS.Shell
             #endregion
 
             #region Console
-            
+
             else if (cmd.Equals("clear"))
             {
                 Console.Clear();
@@ -188,7 +188,13 @@ namespace Alve_OS.Shell
                 {
                     L.Text.Display("directorydoesntexist");
                 }
-            }            
+            }
+
+            else if ((cmd.Equals("dir")) || (cmd.Equals("ls")))
+            {
+                DirectoryListing.DispDirectories(Kernel.current_directory);
+                DirectoryListing.DispFiles(Kernel.current_directory);
+            }
 
             else if ((cmd.StartsWith("dir ")) || (cmd.StartsWith("ls ")))
             {
@@ -198,42 +204,38 @@ namespace Alve_OS.Shell
                 Char cmdargschar = ' ';
                 string[] cmdargs = cmd.Split(cmdargschar);
 
-                if (cmdargs.Length == 2)
-                {
-                    if (!cmdargs[1].StartsWith("-"))
-                    {
-                        directory = cmdargs[1];
 
-                        if (Directory.Exists(directory))
+                if (!cmdargs[1].StartsWith("-"))
+                {
+                    directory = cmdargs[1];
+
+                    if (Directory.Exists(Kernel.current_directory + directory))
+                    {
+                        DirectoryListing.DispDirectories(Kernel.current_directory + directory);
+                        DirectoryListing.DispFiles(Kernel.current_directory + directory);
+                    }
+                }
+                else
+                {
+                    if (cmdargs[1].Equals("-a"))
+                    {
+                        DirectoryListing.DispHiddenDirectories(Kernel.current_directory);
+                        DirectoryListing.DispHiddenFiles(Kernel.current_directory);
+
+                        if (cmdargs.Length == 3)
                         {
-                            DirectoryListing.DispDirectories(directory);
-                            DirectoryListing.DispFiles(directory);
+                            directory = cmdargs[2];
+
+                            DirectoryListing.DispHiddenDirectories(Kernel.current_directory + directory);
+                            DirectoryListing.DispHiddenFiles(Kernel.current_directory + directory);
                         }
                     }
                     else
                     {
-                        if (cmdargs[1].Equals("-a"))
-                        {
-                            DirectoryListing.DispDirectories(Kernel.current_directory);
-                            DirectoryListing.DispHiddenFiles(Kernel.current_directory);
-                        } else
-                        {
-                            directory = Kernel.current_directory;
-                            DirectoryListing.DispDirectories(directory);
-                            DirectoryListing.DispFiles(directory);
-                        }
-                    }                    
-                }
-                else if (cmdargs.Length == 3)
-                {
-                    if (cmdargs[1].Equals("-a"))
-                    {
-                        directory = cmdargs[2];
-
-                        DirectoryListing.DispDirectories(Kernel.current_directory + directory);
-                        DirectoryListing.DispHiddenFiles(Kernel.current_directory + directory);
+                        Console.WriteLine("cet argument est invalide");
                     }
                 }
+
             }
 
             else if (cmd.StartsWith("mkdir "))
@@ -245,6 +247,7 @@ namespace Alve_OS.Shell
                 }
                 else if (Directory.Exists(Kernel.current_directory + dir))
                 {
+                    //normalement ça bug ici
                     Kernel.FS.CreateDirectory(Kernel.current_directory + dir + "-1");
                 }
             }
@@ -311,7 +314,7 @@ namespace Alve_OS.Shell
             else if (cmd.Equals("vol"))
             {
                 var vols = Kernel.FS.GetVolumes();
-                
+
                 L.Text.Display("NameSizeParent");
                 foreach (var vol in vols)
                 {
@@ -418,7 +421,7 @@ namespace Alve_OS.Shell
             #endregion
 
             #region System Infos
-            
+
             else if (cmd.Equals("systeminfo"))
             {
                 L.Text.Display("Computername");
@@ -453,6 +456,6 @@ namespace Alve_OS.Shell
                 Console.ForegroundColor = ConsoleColor.White;
             }
 
-        } 
+        }
     }
 }

--- a/Alve Operating System/Alve OS/Shell/Interpreter.cs
+++ b/Alve Operating System/Alve OS/Shell/Interpreter.cs
@@ -188,59 +188,51 @@ namespace Alve_OS.Shell
                 {
                     L.Text.Display("directorydoesntexist");
                 }
-            }
-
-            else if ((cmd.Equals("dir")) || (cmd.Equals("ls")))
-            {
-                foreach (string dir in Directory.GetDirectories(Kernel.current_directory))
-                {
-                    Color.DisplayTextColor("6");
-                    Console.Write(dir + "\t");
-                }
-                foreach (string file in Directory.GetFiles(Kernel.current_directory))
-                {                    
-                    Char formatDot = '.';
-                    string[] ext = file.Split(formatDot);
-                    string lastext = ext[ext.Length - 1];
-
-                    if ((lastext == "set") || (lastext == "nam") || (lastext == "usr"))
-                    {
-                        Color.DisplayTextColor("4");
-                        Console.Write(file + "\t");
-                    }
-                    else
-                    {
-                        Color.DisplayTextColor("1");
-                        Console.Write(file + "\t");
-                    }
-                }
-                Console.WriteLine();
-            }
+            }            
 
             else if ((cmd.StartsWith("dir ")) || (cmd.StartsWith("ls ")))
             {
-                string directory = Kernel.current_directory;
+                string directory;
 
-                Char cmdargschar = '-';
+                //args commands
+                Char cmdargschar = ' ';
                 string[] cmdargs = cmd.Split(cmdargschar);
 
-                Char cmddirectorychar = ' ';
-                string[] cmddirectories = cmd.Split(cmddirectorychar);
-
-                if (Directory.Exists(cmddirectories[1]))
+                if (cmdargs.Length == 2)
                 {
-                    Console.WriteLine(cmddirectories[1] + " exist !");
-                    directory = cmddirectories[1];
+                    if (!cmdargs[1].StartsWith("-"))
+                    {
+                        directory = cmdargs[1];
+
+                        if (Directory.Exists(directory))
+                        {
+                            DirectoryListing.DispDirectories(directory);
+                            DirectoryListing.DispFiles(directory);
+                        }
+                    }
+                    else
+                    {
+                        if (cmdargs[1].Equals("-a"))
+                        {
+                            DirectoryListing.DispDirectories(Kernel.current_directory);
+                            DirectoryListing.DispHiddenFiles(Kernel.current_directory);
+                        } else
+                        {
+                            directory = Kernel.current_directory;
+                            DirectoryListing.DispDirectories(directory);
+                            DirectoryListing.DispFiles(directory);
+                        }
+                    }                    
                 }
-                else
+                else if (cmdargs.Length == 3)
                 {
+                    if (cmdargs[1].Equals("-a"))
+                    {
+                        directory = cmdargs[2];
 
-                }
-
-                if (cmdargs[1] == "a")
-                {
-                    DirectoryListing.DispDirectories(directory);
-                    DirectoryListing.DispHiddenFiles(directory);
+                        DirectoryListing.DispDirectories(Kernel.current_directory + directory);
+                        DirectoryListing.DispHiddenFiles(Kernel.current_directory + directory);
+                    }
                 }
             }
 

--- a/Alve Operating System/Alve OS/System/Translation/Text/Text.cs
+++ b/Alve Operating System/Alve OS/System/Translation/Text/Text.cs
@@ -182,6 +182,9 @@ namespace Alve_OS.System.Translation
                         case "mkdirunsupporteddot":
                             Console.WriteLine("Vous ne pouvez pas mettre de point(s) dans le nom de votre répertoire.");
                             break;
+                        case "invalidargument":
+                            Console.WriteLine("Cet argument est invalide.");
+                            break;
                     }
                     break;
 
@@ -333,6 +336,9 @@ namespace Alve_OS.System.Translation
                             break;
                         case "mkdirunsupporteddot":
                             Console.WriteLine("You can't have a dot in your directory name.");
+                            break;
+                        case "invalidargument":
+                            Console.WriteLine("This argument is invalid.");
                             break;
                     }
                     break;

--- a/Alve Operating System/Alve OS/System/Translation/Text/Text.cs
+++ b/Alve Operating System/Alve OS/System/Translation/Text/Text.cs
@@ -26,6 +26,7 @@ namespace Alve_OS.System.Translation
         /// </summary>
         /// <param name="ToTranslate">mot clé</param>
         /// <param name="arg">string dynamique</param>
+        /// <param name="arg2">string dynamique</param>
         public static void Display(string ToTranslate, string arg = "", string arg2 = "")
         {
             switch (Kernel.langSelected)

--- a/Alve Operating System/Alve OS/System/Translation/Text/Text.cs
+++ b/Alve Operating System/Alve OS/System/Translation/Text/Text.cs
@@ -170,11 +170,17 @@ namespace Alve_OS.System.Translation
                         case "tips":
                             Console.WriteLine(" * Conseil(s) :");
                             break;
-                        case "foldercontent":
-                            Console.WriteLine("Contenu du dossier '" + arg + "':");
+                        case "mkdir":
+                            Console.WriteLine("Entrez le nom du dossier (mkdir dossier).");
                             break;
                         case "time": //         07/08/2017, 01:12:40
                             Console.WriteLine("Date et heure du système:      " + Time.DayString() + "/" + Time.MonthString() + "/" + Time.YearString() + ", " + Time.HourString() + ":" + Time.MinuteString() + ":" + Time.SecondString());
+                            break;
+                        case "mkdirfilealreadyexist":
+                            Console.WriteLine("Le dossier existait déjà, le répertoire \"" + arg + "\" a donc été créé.");
+                            break;
+                        case "mkdirunsupporteddot":
+                            Console.WriteLine("Vous ne pouvez pas mettre de point(s) dans le nom de votre répertoire.");
                             break;
                     }
                     break;
@@ -316,11 +322,17 @@ namespace Alve_OS.System.Translation
                         case "tips":
                             Console.WriteLine(" * Tips :");
                             break;
-                        case "foldercontent":
-                            Console.WriteLine("Folder's content of '" + arg + "':");
+                        case "mkdir":
+                            Console.WriteLine("Enter the directory name (mkdir directory).");
                             break;
                         case "time":
                             Console.WriteLine("Date and time:             " + Time.MonthString() + "/" + Time.DayString() + "/" + Time.YearString() + ", " + Time.HourString() + ":" + Time.MinuteString() + ":" + Time.SecondString());
+                            break;
+                        case "mkdirfilealreadyexist":
+                            Console.WriteLine("That folder existed already, directory \"" + arg + "\" has been created.");
+                            break;
+                        case "mkdirunsupporteddot":
+                            Console.WriteLine("You can't have a dot in your directory name.");
                             break;
                     }
                     break;


### PR DESCRIPTION
### Features

- [x] Hidden files.
- [x] Add "(number)" at end of directories name if directory exist when mkdir is called.
- [x] Display error message when a directory contains a dot.
- [x] Hidden files are displayed with another color with ls -a to reconize them.
- [x] Add possibility to add arguments to ls/dir commands in the future.

* Hidden directories can't exist because of a bug of FAT in Cosmos.

_Clear the disk is recommended after push._

PS: J'en ai chier, vas-y test, et dis moi si ça te va @valentinbreiz mdr.